### PR TITLE
Compute and Transfer Example Flows

### DIFF
--- a/compute_transfer_examples/README.md
+++ b/compute_transfer_examples/README.md
@@ -42,7 +42,7 @@ The parameters `transform_from` and `transform_to` handle differences between pa
 
 Thus, the Compute function must be provided with the GCS root mapping to do any needed transformations. In this example:
 - Set `transform_to` to the mapped root path (`/path/to/root/`) to transform the input `src_paths` to absolute paths.
-- Set `transform_from` to the root directory (`/`) to transform the absolute paths to Globus paths.
+- Set `transform_from` to the root directory (`/`) to transform the absolute paths to the paths in the GCS collection.
 
 These transformations ensure the Compute function can correctly locate and access files regardless of how collection paths are mapped.
 

--- a/compute_transfer_examples/README.md
+++ b/compute_transfer_examples/README.md
@@ -5,7 +5,7 @@ This guide demonstrates how to build flows that combine Globus Compute and Globu
 ## Prerequisites
 
 Before starting, ensure you have a shared GCS collection and Globus Compute endpoint.
-If you haven't set these up, follow [this guide](https://docs.globus.org/globus-connect-server/v5.4/) for setting up the GCS collection, and [this guide](https://globus-compute.readthedocs.io/en/latest/endpoints/installation.html) for setting up the Globus Compute endpoint. **Note**: The GCS collection and Globus Compute endpoint must have access to the same filesystem at the same path.
+If you haven't set these up, follow [this guide](https://docs.globus.org/globus-connect-server/v5.4/) for setting up the GCS collection, and [this guide](https://globus-compute.readthedocs.io/en/latest/endpoints/installation.html) for setting up the Globus Compute endpoint. **Note**: The GCS collection and Globus Compute endpoint must both have read/write permissions to the same filesystem location where operations will be performed.
 
 ## Register the Globus Compute Function
 
@@ -15,7 +15,7 @@ First, register the `do_tar` Compute function that your flows will invoke to cre
 ./transfer_compute_example/register_compute_func.py
 ```
 
-and copy down the Compute function's UUID.
+and save the Compute function's UUID.
 
 **Important**: Use the same Python version for registration as the one running on your Globus Compute Endpoint.
 
@@ -50,7 +50,7 @@ These transformations ensure the Compute function can correctly locate and acces
 In the first example, the Compute and Transfer flow takes a user-provided source file that already exists in the co-located GCS collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
 1. Set constants for the run
 2. Create an output directory named after the flow's run ID on your GCS collection
-3. Invoke the Compute function `do_tar` on the source file and create a tarfile in the output directory
+3. Invoke the Compute function `do_tar` on the source endpoint to create a tar archive from the input source file and save it in the output directory
 4. Transfer the resulting tarfile to the destination collection provided in the flow input
 5. Delete the output directory
 
@@ -59,8 +59,8 @@ In the first example, the Compute and Transfer flow takes a user-provided source
 1. Edit `compute_transfer_examples/compute_transfer_example_1_definition.json` and replace the placeholder values:
    - `gcs_endpoint_id`: Your GCS Collection ID
    - `compute_endpoint_id`: Your Compute Endpoint ID
-   - `compute_func_id`: The UUID of the registered `do_tar` function
-   - `compute_transform_from` and `compute_transform_to`: If your GCS collection uses path mapping
+   - `compute_function_id`: The UUID of the registered `do_tar` function
+   - `compute_transform_from` and `compute_transform_to`: If your GCS collection uses [base path mapping](https://docs.globus.org/globus-connect-server/v5/data-access-guide/#configure_collection_base_path)
 
 2. Register the flow:
    ```bash
@@ -84,10 +84,11 @@ In the first example, the Compute and Transfer flow takes a user-provided source
 
 2. Start the flow:
    ```bash
-   globus flows start <FLOW_ID> \
+   globus flows start <YOUR FLOW ID> \
      --input <YOUR FLOW INPUT FILE> \
      --label "Compute and Transfer Flow Example 1 Run"
    ```
+   And save the run ID for use in the next command.
 
 3. Monitor the run progress:
    ```bash
@@ -95,12 +96,12 @@ In the first example, the Compute and Transfer flow takes a user-provided source
    ```
 
 ## Compute and Transfer Flow: Example 2
-In the second example, the Compute and Transfer flow takes in a user provided list source files that exists on a user provided source collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
+In the second example, the Compute and Transfer flow takes in a user-provided list source files that exists on a user provided source collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
 1. Set constants for the run
 2. Create an output directory named after the flow's run ID on your GCS collection
 3. Iterate through the list of input source files and create the destination paths for files on your GCS collection
 4. Transfer the source paths from the user-provided source collection to the newly created output directory folder on your GCS collection
-5. Invoke the Compute function `do_tar` on the source files and create a tarfile in the output directory
+5. Invoke the Compute function `do_tar` on the source endpoint to create a tar archive from the input source files and save it in the output directory
 6. Transfer the resulting tarfile to the destination collection provided in the flow input
 7. Delete the output directory
 
@@ -125,6 +126,8 @@ In the second example, the Compute and Transfer flow takes in a user provided li
      --input-schema ./compute_transfer_examples/compute_transfer_example_2_schema.json
    ```
 
+3. Save the Flow ID returned by this command
+
 ### Running the Flow
 
 1. Create the input json file for your flow:
@@ -145,6 +148,7 @@ In the second example, the Compute and Transfer flow takes in a user provided li
      --input <YOUR FLOW INPUT FILE> \
      --label "Compute and Transfer Flow Example 2 Run"
    ```
+   And save the run ID for use in the next command.
 
 3. Monitor the run progress:
    ```bash

--- a/compute_transfer_examples/README.md
+++ b/compute_transfer_examples/README.md
@@ -1,0 +1,152 @@
+# Globus Compute and Transfer Flow Examples
+
+This guide demonstrates how to build flows that combine Globus Compute and Globus Transfer to process and move data. You'll learn how to create two different flows that archive (tar) files and transfer them from a source collection to a destination collection.
+
+## Prerequisites
+
+Before starting, ensure you have a shared GCS collection and Globus Compute endpoint.
+If you haven't set these up, follow [this guide](https://docs.globus.org/globus-connect-server/v5.4/) for setting up the GCS collection, and [this guide](https://globus-compute.readthedocs.io/en/latest/endpoints/installation.html) for setting up the Globus Compute endpoint. **Note**: The GCS collection and Globus Compute endpoint must have access to the same filesystem at the same path.
+
+## Register the Globus Compute Function
+
+First, register the `do_tar` Compute function that your flows will invoke to create the output tarfiles. Run the provided python script:
+
+```bash
+./transfer_compute_example/register_compute_func.py
+```
+
+and copy down the Compute function's UUID.
+
+**Important**: Use the same Python version for registration as the one running on your Globus Compute Endpoint.
+
+### The `do_tar` Compute function
+
+`do_tar` takes four parameters that the flow will need to provide:
+
+| Parameter | Description |
+|-----------|-------------|
+| `src_paths` | String or list of path(s) to files/directories to archive |
+| `dest_path` | Where to write the tar.gz archive (directory or file path) |
+| `transform_from` | The path prefix to replace (default: "/") |
+| `transform_to` | The prefix to use for absolute paths (default: "/") |
+
+### Path Transformation Explained
+
+The path transformation parameters `transform_from` and `transform_to` handle differences between how paths appear in the Globus ecosystem versus how they exist on the actual GCS collection's filesystem.
+
+**Example scenario:**
+- Your GCS collection maps its root to the absolute path `/path/to/root/`.
+- A user wants to tar the files at the absolute path `/path/to/root/input_files/`.
+- To both the user and Flows service, this path appears as `/input_files/` on the GCS collection.
+- However, the Compute function running on the GCS collection **does not know** about the mapping and can only find the files with the absolute paths.
+
+Thus, the Compute function must be provided with the GCS root mapping to do any needed transformations. In this example:
+- Set `transform_to` to the mapped root path (`/path/to/root/`) to transform the input src_paths to absolute paths.
+- Set `transform_from` to the root directory (`/`) to transform the absolute paths to Globus paths.
+
+These transformations ensure the Compute function can correctly locate and access files regardless of how collection paths are mapped.
+
+## Compute and Transfer Flow: Example 1
+In the first example, the Compute and Transfer flow takes in a user provided single source file that exists on your GCS collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
+1. Set constants for the run
+2. Create an output directory named after the flow's run ID on your GCS collection
+3. Invoke the Compute function `do_tar` on the source file and create a tarfile in the output directory
+4. Transfer the resulting tarfile to the destination collection provided in the flow input
+5. Delete the output directory
+
+### Registering the Flow
+
+1. Edit `compute_transfer_examples/compute_transfer_example_1_definition.json` and replace the placeholder values:
+   - `gcs_endpoint_id`: Your GCS Collection ID
+   - `compute_endpoint_id`: Your Compute Endpoint ID
+   - `compute_func_id`: The UUID of the registered `do_tar` function
+   - `compute_transform_from` and `compute_transform_to`: If your GCS collection uses path mapping
+
+2. Register the flow:
+   ```bash
+   globus flows create "Compute and Transfer Flow Example 1" \
+     ./compute_transfer_examples/compute_transfer_example_1_definition.json \
+     --input-schema ./compute_transfer_examples/compute_transfer_example_1_schema.json
+   ```
+
+3. Save the Flow ID returned by this command
+
+### Running the Flow
+
+1. Create the flow input json file like so:
+   ```json
+   {
+       "source_path": "/path/to/your/source/file",
+       "destination_path": "/path/to/your/destination/file.tar.gz",
+       "destination_endpoint_id": "your-destination-endpoint-uuid"
+   }
+   ```
+
+2. Start the flow:
+   ```bash
+   globus flows start <FLOW_ID> \
+     --input <YOUR FLOW INPUT FILE> \
+     --label "Compute and Transfer Flow Example 1 Run"
+   ```
+
+3. Monitor the run progress:
+   ```bash
+   globus flows run show <RUN_ID>
+   ```
+
+## Compute and Transfer Flow: Example 2
+In the second example, the Compute and Transfer flow takes in a user provided list source files that exists on a user provided source collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
+1. Set constants for the run
+2. Create an output directory named after the flow's run ID on your GCS collection
+3. Iterate through the list of input source files and create the destination paths for files on your GCS collection
+4. Transfer the source paths from the user-provided source collection to the newly created output directory folder on your GCS collection
+5. Invoke the Compute function `do_tar` on the source files and create a tarfile in the output directory
+6. Transfer the resulting tarfile to the destination collection provided in the flow input
+7. Delete the output directory
+
+**Implementation Note**: Step 3 is implemented using six different states in the flow definition (`SetSourcePathsIteratorVariables`, `EvalShouldIterateSourcePaths`, `IterateSourcePaths`, `EvalGetSourcePath`, `GetSourcePathInfo`, and `EvalSourcePathInfo`). These states work together to create a loop that processes each source path. While this demonstrates how to implement an iteration in Flows, a simpler approach could be to create a separate Compute function to handle this work, which would significantly reduce the complexity of this flow.
+
+### Registering the Flow
+
+1. Edit `compute_transfer_examples/compute_transfer_example_2_definition.json` and replace the placeholder values (same as in the first example).
+
+2. Register as a new flow:
+   ```bash
+   globus flows create "Compute and Transfer Flow Example 2" \
+     ./compute_transfer_examples/compute_transfer_example_2_definition.json \
+     --input-schema ./compute_transfer_examples/compute_transfer_example_2_schema.json
+   ```
+
+   Or update the existing flow from example 1:
+   ```bash
+   globus flows update <FLOW_ID> \
+     --title "Compute and Transfer Flow Example 2" \
+     --definition ./compute_transfer_examples/compute_transfer_example_2_definition.json \
+     --input-schema ./compute_transfer_examples/compute_transfer_example_2_schema.json
+   ```
+
+### Running the Flow
+
+1. Create the input json file for your flow:
+   ```json
+   {
+       "source_endpoint": "your-source-endpoint-uuid",
+       "source_paths": ["/path/to/file1", "/path/to/file2"],
+       "destination": {
+           "id": "your-destination-endpoint-uuid",
+           "path": "/path/to/your/destination/archive.tar.gz"
+       }
+   }
+   ```
+
+2. Start the flow:
+   ```bash
+   globus flows start <FLOW_ID> \
+     --input <YOUR FLOW INPUT FILE> \
+     --label "Compute and Transfer Flow Example 2 Run"
+   ```
+
+3. Monitor the run progress:
+   ```bash
+   globus flows run show <RUN_ID>
+   ```

--- a/compute_transfer_examples/README.md
+++ b/compute_transfer_examples/README.md
@@ -4,15 +4,21 @@ This guide demonstrates how to build flows that combine Globus Compute and Globu
 
 ## Prerequisites
 
-Before starting, ensure you have a shared GCS collection and Globus Compute endpoint.
+Before starting, ensure you have a co-located GCS collection and Globus Compute endpoint.
 If you haven't set these up, follow [this guide](https://docs.globus.org/globus-connect-server/v5.4/) for setting up the GCS collection, and [this guide](https://globus-compute.readthedocs.io/en/latest/endpoints/installation.html) for setting up the Globus Compute endpoint. **Note**: The GCS collection and Globus Compute endpoint must both have read/write permissions to the same filesystem location where operations will be performed.
+
+You will also need to have installed the `globus-cli` and the `globus-compute-sdk` python package. You can install these with:
+```bash
+pip install globus-cli globus-compute-sdk
+```
+**Note**: It is recommended that you work inside a virtual environment for this tutorial.
 
 ## Register the Globus Compute Function
 
 First, register the `do_tar` Compute function that your flows will invoke to create the output tarfiles. Run the provided python script:
 
 ```bash
-./transfer_compute_example/register_compute_func.py
+./register_compute_func.py
 ```
 
 and save the Compute function's UUID.
@@ -27,22 +33,22 @@ and save the Compute function's UUID.
 |-----------|-------------|
 | `src_paths` | List of paths to the files/directories to be archived |
 | `dest_path` | Where to write the tar archive (directory or file path) |
-| `gcs_base_path` | The shared GCS collection's configured base path. (default: "/") |
+| `gcs_base_path` | The co-located GCS collection's configured base path. (default: "/") |
 
 ### GCS Collection Base Paths
 
-The parameter `gcs_base_path` is provided to the compute function to allow it to transform the user input paths to absolute paths. This is needed when the shared GCS instance has [configured the collection's base path](https://docs.globus.org/globus-connect-server/v5/data-access-guide/#configure_collection_base_path).
+The `gcs_base_path` parameter is provided to the Compute function to allow it to transform the user input paths to absolute paths. This is needed when the co-located GCS instance has [configured the collection's base path](https://docs.globus.org/globus-connect-server/v5/data-access-guide/#configure_collection_base_path).
 
 **Example scenario:**
 - Your GCS collection has configured its base path to `/path/to/root/`.
 - A user wants to tar the files at the absolute path `/path/to/root/input_files/`.
 - To both the user and Flows service, this path appears as `/input_files/` on the GCS collection.
-- However, the Compute function running on the shared GCS instance **does not know** about the collection's configured base path and can only find the files using absolute paths.
+- However, the Compute function running on the co-located GCS instance **does not know** about the collection's configured base path and can only find the files using absolute paths.
 
 Thus, the Compute function must be provided with the GCS collection's configured base path to do the necessary transformations. In this example, `gcs_base_path` would need to be set to `/path/to/root/`.
 
 ## Compute and Transfer Flow: Example 1
-In the first example, the Compute and Transfer flow takes a user-provided list of source files that **already** exists in the co-located GCS collection, creates a tarfile from them, and transfers the tarfile to a user-provided destination collection. Specifically, the flow will:
+In the first example, the Compute and Transfer flow takes a user-provided list of source files that **already** exist in the co-located GCS collection, creates a tarfile from them, and transfers the tarfile to a user-provided destination collection. Specifically, the flow will:
 1. Set constants for the run
 2. Create an output directory named after the flow's run ID on your GCS collection
 3. Invoke the Compute function `do_tar` on the source endpoint to create a tar archive from the input source files and save it in the output directory
@@ -51,7 +57,7 @@ In the first example, the Compute and Transfer flow takes a user-provided list o
 
 ### Registering the Flow
 
-1. Edit `compute_transfer_examples/compute_transfer_example_1_definition.json` and replace the placeholder values:
+1. Edit `compute_transfer_example_1_definition.json` and replace the placeholder values:
    - `gcs_endpoint_id`: Your GCS Collection ID
    - `compute_endpoint_id`: Your Compute Endpoint ID
    - `compute_function_id`: The UUID of the registered `do_tar` function
@@ -62,11 +68,11 @@ If your GCS collection has a configured base path, also edit `gcs_base_path`.
 2. Register the flow:
    ```bash
    globus flows create "Compute and Transfer Flow Example 1" \
-     ./compute_transfer_examples/compute_transfer_example_1_definition.json \
-     --input-schema ./compute_transfer_examples/compute_transfer_example_1_schema.json
+     ./compute_transfer_example_1_definition.json \
+     --input-schema ./compute_transfer_example_1_schema.json
    ```
 
-3. Save the Flow ID returned by this command
+3. Save the flow ID returned by this command
 
 ### Running the Flow
 
@@ -91,45 +97,45 @@ If your GCS collection has a configured base path, also edit `gcs_base_path`.
    ```bash
    globus flows run show <RUN_ID>
    ```
-   At this point, you might see that your flow has gone INACTIVE. This is because you need to give data access consents for any GCS collection that your flow is interacting with. Run the command:
+   At this point, you might see that your flow has become INACTIVE. This is because you need to give data access consents for any GCS collection that your flow is interacting with. Run the command:
 
    ```bash
    globus flows run resume <RUN_ID>
    ```
-   And you will be prompted to run a `globus session consent`. After granting the requested consent, try resuming the run once again and your flow should be able to proceed. As your flow encounters more required data access consents, you might need to repeat this step multiple times, however once you have granted a consent, it will remain for all future runs of that flow.
+   And you will be prompted to run a `globus session consent`. After granting the requested consent, try resuming the run once again and your flow should be able to proceed. As your flow interacts with other collections, it may encounter additional `data_access` consents. If so, you might need to repeat this step. Once you have granted consents to a flow, it will remain (until revoked) for future runs of that flow with the same client that was used to grant the consent.
 
 ## Compute and Transfer Flow: Example 2
-In the second example, the Compute and Transfer flow takes in a user-provided list of source files that exist on a user-provided source collection, creates a tarfile from it, and transfers the tarfile to a user-provided destination collection. Specifically, the flow will:
+In the second example, the Compute and Transfer flow takes a user-provided list of source files that exist on a user-provided source collection, transfers the source files to your GCS collection, creates a tarfile from them, and transfers the tarfile to a user-provided destination collection. Specifically, the flow will:
 1. Set constants for the run
-2. Create an output directory named after the flow's run ID on your GCS collection
-3. Iterate through the list of input source files and create the destination paths for files on your GCS collection
-4. Transfer the source paths from the user-provided source collection to the newly created output directory folder on your GCS collection
+2. Create an output directory named after the flow's run ID on your intermediate GCS collection
+3. Iterate through the list of input source files and create the destination paths for files on your intermediate GCS collection
+4. Transfer the source paths from the user-provided source collection to the newly created output directory folder on your intermediate GCS collection
 5. Invoke the Compute function `do_tar` on the source endpoint to create a tar archive from the input source files and save it in the output directory
 6. Transfer the resulting tarfile to the destination collection provided in the flow input
-7. Delete the output directory
+7. Delete the output directory on your intermediate GCS collection
 
-**Implementation Note**: Step 3 is implemented using six different states in the flow definition (`SetSourcePathsIteratorVariables`, `EvalShouldIterateSourcePaths`, `IterateSourcePaths`, `EvalGetSourcePath`, `GetSourcePathInfo`, and `EvalSourcePathInfo`). These states work together to create a loop that processes each source path. While this demonstrates how to implement an iteration in Flows, a simpler approach could be to create a separate Compute function to handle this work, which would significantly reduce the complexity of this flow.
+**Implementation Note**: Step 3 is implemented using six different states in the flow definition (`SetSourcePathsIteratorVariables`, `EvalShouldIterateSourcePaths`, `IterateSourcePaths`, `EvalGetSourcePath`, `GetSourcePathInfo`, and `EvalSourcePathInfo`). These states work together to create a loop that processes each source path. While this demonstrates how to implement a loop in Flows, a simpler approach could be to create a separate Compute function to handle this work, which would significantly reduce the complexity of this flow.
 
 ### Registering the Flow
 
-1. Edit `compute_transfer_examples/compute_transfer_example_2_definition.json` and replace the placeholder values (same as in the first example).
+1. Edit `compute_transfer_example_2_definition.json` and replace the placeholder values (same as in the first example).
 
 2. Register as a new flow:
    ```bash
    globus flows create "Compute and Transfer Flow Example 2" \
-     ./compute_transfer_examples/compute_transfer_example_2_definition.json \
-     --input-schema ./compute_transfer_examples/compute_transfer_example_2_schema.json
+     ./compute_transfer_example_2_definition.json \
+     --input-schema ./compute_transfer_example_2_schema.json
    ```
 
    Or update the existing flow from example 1:
    ```bash
    globus flows update <FLOW_ID> \
      --title "Compute and Transfer Flow Example 2" \
-     --definition ./compute_transfer_examples/compute_transfer_example_2_definition.json \
-     --input-schema ./compute_transfer_examples/compute_transfer_example_2_schema.json
+     --definition ./compute_transfer_example_2_definition.json \
+     --input-schema ./compute_transfer_example_2_schema.json
    ```
 
-3. Save the Flow ID returned by this command
+3. Save the flow ID returned by this command
 
 ### Running the Flow
 

--- a/compute_transfer_examples/README.md
+++ b/compute_transfer_examples/README.md
@@ -32,7 +32,7 @@ and copy down the Compute function's UUID.
 
 ### Path Transformation Explained
 
-The path transformation parameters `transform_from` and `transform_to` handle differences between how paths appear in the Globus ecosystem versus how they exist on the actual GCS collection's filesystem.
+The parameters `transform_from` and `transform_to` handle differences between paths as exposed by the GCS collection and paths on the underlying filesystem.
 
 **Example scenario:**
 - Your GCS collection maps its root to the absolute path `/path/to/root/`.
@@ -41,13 +41,13 @@ The path transformation parameters `transform_from` and `transform_to` handle di
 - However, the Compute function running on the GCS collection **does not know** about the mapping and can only find the files with the absolute paths.
 
 Thus, the Compute function must be provided with the GCS root mapping to do any needed transformations. In this example:
-- Set `transform_to` to the mapped root path (`/path/to/root/`) to transform the input src_paths to absolute paths.
+- Set `transform_to` to the mapped root path (`/path/to/root/`) to transform the input `src_paths` to absolute paths.
 - Set `transform_from` to the root directory (`/`) to transform the absolute paths to Globus paths.
 
 These transformations ensure the Compute function can correctly locate and access files regardless of how collection paths are mapped.
 
 ## Compute and Transfer Flow: Example 1
-In the first example, the Compute and Transfer flow takes in a user provided single source file that exists on your GCS collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
+In the first example, the Compute and Transfer flow takes a user-provided source file that already exists in the co-located GCS collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection. Specifically, the flow will:
 1. Set constants for the run
 2. Create an output directory named after the flow's run ID on your GCS collection
 3. Invoke the Compute function `do_tar` on the source file and create a tarfile in the output directory

--- a/compute_transfer_examples/compute_transfer_example_1_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_1_definition.json
@@ -5,10 +5,9 @@
       "Type": "ExpressionEval",
       "Parameters": {
         "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
+        "gcs_base_path": "/",
         "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
         "compute_function_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
-        "compute_transform_from": "/",
-        "compute_transform_to": "/",
         "compute_output_directory.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
@@ -34,10 +33,9 @@
             "function_id.$": "$.constants.compute_function_id",
             "args": [],
             "kwargs": {
-              "src_paths.$" : "$.source_path",
+              "src_paths.$" : "$.source_paths",
               "dest_path.$" : "$.constants.compute_output_directory",
-              "transform_from.$": "$.constants.compute_transform_from",
-              "transform_to.$": "$.constants.compute_transform_to"
+              "gcs_base_path.$": "$.constants.gcs_base_path"
             }
           }
         ]

--- a/compute_transfer_examples/compute_transfer_example_1_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_1_definition.json
@@ -6,10 +6,10 @@
       "Parameters": {
         "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
         "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
-        "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
+        "compute_function_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
         "compute_transform_from": "/",
         "compute_transform_to": "/",
-        "compute_dest_path.=": "'/' + _context.run_id + '/'"
+        "compute_output_directory.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
       "Next" : "MakeComputeWorkingDir"
@@ -19,7 +19,7 @@
       "ActionUrl": "https://transfer.actions.globus.org/mkdir",
       "Parameters": {
         "endpoint_id.$": "$.constants.gcs_endpoint_id",
-        "path.$": "$.constants.compute_dest_path"
+        "path.$": "$.constants.compute_output_directory"
       },
       "ResultPath": "$.mkdir_result",
       "Next": "RunComputeFunction"
@@ -31,11 +31,11 @@
         "endpoint_id.$": "$.constants.compute_endpoint_id",
         "tasks": [
           {
-            "function_id.$": "$.constants.compute_func_id",
+            "function_id.$": "$.constants.compute_function_id",
             "args": [],
             "kwargs": {
               "src_paths.$" : "$.source_path",
-              "dest_path.$" : "$.constants.compute_dest_path",
+              "dest_path.$" : "$.constants.compute_output_directory",
               "transform_from.$": "$.constants.compute_transform_from",
               "transform_to.$": "$.constants.compute_transform_to"
             }
@@ -69,7 +69,7 @@
         "recursive": true,
         "DATA": [
           {
-            "path.$": "$.constants.compute_dest_path"
+            "path.$": "$.constants.compute_output_directory"
           }
         ]
       },

--- a/compute_transfer_examples/compute_transfer_example_1_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_1_definition.json
@@ -1,0 +1,80 @@
+{
+  "StartAt": "SetConstants",
+  "States" : {
+    "SetConstants": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
+        "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
+        "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
+        "compute_transform_from": "/",
+        "compute_transform_to": "/",
+        "compute_dest_path.=": "'/~/' + _context.run_id + '/'"
+      },
+      "ResultPath": "$.constants",
+      "Next" : "MakeComputeWorkingDir"
+    },
+    "MakeComputeWorkingDir": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/mkdir",
+      "Parameters": {
+        "endpoint_id.$": "$.constants.gcs_endpoint_id",
+        "path.$": "$.constants.compute_dest_path"
+      },
+      "ResultPath": "$.mkdir_result",
+      "Next": "RunComputeFunction"
+    },
+    "RunComputeFunction": {
+      "Type": "Action",
+      "ActionUrl": "https://compute.actions.globus.org/v3",
+      "Parameters": {
+        "endpoint_id.$": "$.constants.compute_endpoint_id",
+        "tasks": [
+          {
+            "function_id.$": "$.constants.compute_func_id",
+            "args": [],
+            "kwargs": {
+              "src_path.$" : "$.source_path",
+              "dest_path.$" : "$.constants.compute_dest_path",
+              "transform_from.$": "$.constants.compute_transform_from",
+              "transform_to.$": "$.constants.compute_transform_to"
+            }
+          }
+        ]
+      },
+      "ResultPath": "$.compute_result",
+      "Next" : "TransferFromComputeEndpoint"
+    },
+    "TransferFromComputeEndpoint": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/transfer",
+      "Parameters": {
+        "source_endpoint.$": "$.constants.gcs_endpoint_id",
+        "destination_endpoint.$": "$.destination_endpoint_id",
+        "DATA": [
+          {
+            "source_path.=": "compute_result.details.result[0]",
+            "destination_path.$": "$.destination_path"
+          }
+        ]
+      },
+      "ResultPath": "$.transfer_to_dest_result",
+      "Next" : "CleanupComputeEndpoint"
+    },
+    "CleanupComputeEndpoint": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/delete",
+      "Parameters": {
+        "endpoint.$": "$.constants.gcs_endpoint_id",
+        "recursive": true,
+        "DATA": [
+          {
+            "path.$": "$.constants.compute_dest_path"
+          }
+        ]
+      },
+      "ResultPath": "$.delete_compute_output_result",
+      "End" : true
+    }
+  }
+}

--- a/compute_transfer_examples/compute_transfer_example_1_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_1_definition.json
@@ -9,7 +9,7 @@
         "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
         "compute_transform_from": "/",
         "compute_transform_to": "/",
-        "compute_dest_path.=": "'/~/' + _context.run_id + '/'"
+        "compute_dest_path.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
       "Next" : "MakeComputeWorkingDir"
@@ -34,7 +34,7 @@
             "function_id.$": "$.constants.compute_func_id",
             "args": [],
             "kwargs": {
-              "src_path.$" : "$.source_path",
+              "src_paths.$" : "$.source_path",
               "dest_path.$" : "$.constants.compute_dest_path",
               "transform_from.$": "$.constants.compute_transform_from",
               "transform_to.$": "$.constants.compute_transform_to"

--- a/compute_transfer_examples/compute_transfer_example_1_schema.json
+++ b/compute_transfer_examples/compute_transfer_example_1_schema.json
@@ -1,15 +1,15 @@
 {
   "type": "object",
   "required": [
-    "source_path",
+    "source_paths",
     "destination_path",
     "destination_endpoint_id"
   ],
   "properties": {
-    "source_path": {
-      "type": "string",
-      "title": "Source Collection Path",
-      "description": "The path on the source collection for the data"
+    "source_paths": {
+      "type": "array",
+      "title": "Source Collection Paths",
+      "description": "A list of paths on the source collection for the data"
     },
     "destination_path": {
       "type": "string",

--- a/compute_transfer_examples/compute_transfer_example_1_schema.json
+++ b/compute_transfer_examples/compute_transfer_example_1_schema.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "required": [
+    "source_path",
+    "destination_path",
+    "destination_endpoint_id"
+  ],
+  "properties": {
+    "source_path": {
+      "type": "string",
+      "title": "Source Collection Path",
+      "description": "The path on the source collection for the data"
+    },
+    "destination_path": {
+      "type": "string",
+      "title": "Destination Collection Path",
+      "description": "The path on the destination collection for the data"
+    },
+    "destination_endpoint_id": {
+      "type": "string",
+      "title": "Destination Collection Endpoint ID",
+      "description": "The endpoint id of destination collection"
+    }
+  },
+  "additionalProperties": false
+}

--- a/compute_transfer_examples/compute_transfer_example_2_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_2_definition.json
@@ -5,10 +5,9 @@
       "Type": "ExpressionEval",
       "Parameters": {
         "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
+        "gcs_base_path": "/",
         "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
         "compute_function_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
-        "compute_transform_from": "/",
-        "compute_transform_to": "/",
         "compute_output_directory.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
@@ -104,8 +103,7 @@
             "kwargs": {
               "src_paths.$" : "$.iterator_vars.compute_src_paths",
               "dest_path.$" : "$.constants.compute_output_directory",
-              "transform_from.$": "$.constants.compute_transform_from",
-              "transform_to.$": "$.constants.compute_transform_to"
+              "gcs_base_path.$": "$.constants.gcs_base_path"
             }
           }
         ]

--- a/compute_transfer_examples/compute_transfer_example_2_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_2_definition.json
@@ -1,0 +1,148 @@
+{
+  "StartAt": "SetConstants",
+  "States" : {
+    "SetConstants": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
+        "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
+        "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
+        "compute_transform_from": "/",
+        "compute_transform_to": "/",
+        "compute_dest_path.=": "'/~/' + _context.run_id + '/'"
+      },
+      "ResultPath": "$.constants",
+      "Next" : "MakeComputeWorkingDir"
+    },
+    "MakeComputeWorkingDir": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/mkdir",
+      "Parameters": {
+        "endpoint_id.$": "$.constants.gcs_endpoint_id",
+        "path.$": "$.constants.compute_dest_path"
+      },
+      "ResultPath": "$.mkdir_result",
+      "Next": "SetSourcePathsIteratorVariables"
+    },
+    "SetSourcePathsIteratorVariables": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "src_paths_iterator_pos": 0,
+        "compute_src_paths" : [],
+        "transfer_from_src_data": []
+      },
+      "ResultPath": "$.iterator_vars",
+      "Next" : "EvalShouldIterateSourcePaths"
+    },
+    "EvalShouldIterateSourcePaths": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "should_iterate.=": "len(source_paths) > iterator_vars.src_paths_iterator_pos"
+      },
+      "ResultPath": "$.iterate_eval",
+      "Next" : "IterateSourcePaths"
+    },
+    "IterateSourcePaths" : {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.iterate_eval.should_iterate",
+          "BooleanEquals": true,
+          "Next": "EvalGetSourcePath"
+        }
+      ],
+      "Default": "TransferToComputeEndpoint"
+    },
+    "EvalGetSourcePath": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "source_path.=": "source_paths[iterator_vars.src_paths_iterator_pos]"
+      },
+      "ResultPath": "$.get_path",
+      "Next" : "GetSourcePathInfo"
+    },
+    "GetSourcePathInfo": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/stat",
+      "Parameters": {
+        "endpoint_id.$": "$.source_endpoint",
+        "path.$": "$.get_path.source_path"
+      },
+      "ResultPath": "$.source_path_stat_result",
+      "Next" : "EvalSourcePathInfo"
+    },
+    "EvalSourcePathInfo": {
+      "Type": "ExpressionEval",
+      "Parameters": {
+        "compute_src_paths.=": "iterator_vars.compute_src_paths + [constants.compute_dest_path + source_path_stat_result.details.name]",
+        "transfer_from_src_data.=": "iterator_vars.transfer_from_src_data + [{'source_path': get_path.source_path, 'destination_path': constants.compute_dest_path + source_path_stat_result.details.name}]",
+        "src_paths_iterator_pos.=": "iterator_vars.src_paths_iterator_pos + 1"
+      },
+      "ResultPath": "$.iterator_vars",
+      "Next" : "EvalShouldIterateSourcePaths"
+    },
+    "TransferToComputeEndpoint": {  
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/transfer",
+      "Parameters": {
+        "source_endpoint.$": "$.source_endpoint",
+        "destination_endpoint.$": "$.constants.gcs_compute_endpoint_id",
+        "DATA.$": "$.iterator_vars.intermidate_transfer_data"
+      },
+      "ResultPath": "$.transfer_from_src_result",
+      "Next" : "RunComputeFunction"
+    },
+    "RunComputeFunction": {
+      "Type": "Action",
+      "ActionUrl": "https://compute.actions.globus.org/v3",
+      "Parameters": {
+        "endpoint_id.$": "$.constants.compute_endpoint_id",
+        "tasks": [
+          {
+            "function_id.$": "$.constants.compute_func_id",
+            "args": [],
+            "kwargs": {
+              "src_path.$" : "$.iterator_vars.compute_src_paths",
+              "dest_path.$" : "$.constants.compute_dest_path",
+              "transform_from.$": "$.constants.compute_transform_from",
+              "transform_to.$": "$.constants.compute_transform_to"
+            }
+          }
+        ]
+      },
+      "ResultPath": "$.compute_result",
+      "Next" : "TransferFromComputeEndpoint"
+    },
+    "TransferFromComputeEndpoint": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/transfer",
+      "Parameters": {
+        "source_endpoint.$": "$.constants.gcs_compute_endpoint_id",
+        "destination_endpoint.$": "$.destination.id",
+        "DATA": [
+          {
+            "source_path.=": "compute_result.details.result[0]",
+            "destination_path.$": "$.destination.path"
+          }
+        ]
+      },
+      "ResultPath": "$.transfer_to_dest_result",
+      "Next": "CleanupComputeEndpoint"
+    },
+    "CleanupComputeEndpoint": {
+      "Type": "Action",
+      "ActionUrl": "https://transfer.actions.globus.org/delete",
+      "Parameters": {
+        "endpoint.$": "$.constants.gcs_compute_endpoint_id",
+        "recursive": true,
+        "DATA": [
+          {
+            "path.$": "$.constants.compute_dest_path"
+          }
+        ]
+      },
+      "ResultPath": "$.delete_compute_output_result",
+      "End" : true
+    }
+  }
+}

--- a/compute_transfer_examples/compute_transfer_example_2_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_2_definition.json
@@ -9,7 +9,7 @@
         "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
         "compute_transform_from": "/",
         "compute_transform_to": "/",
-        "compute_dest_path.=": "'/~/' + _context.run_id + '/'"
+        "compute_dest_path.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
       "Next" : "MakeComputeWorkingDir"
@@ -86,8 +86,8 @@
       "ActionUrl": "https://transfer.actions.globus.org/transfer",
       "Parameters": {
         "source_endpoint.$": "$.source_endpoint",
-        "destination_endpoint.$": "$.constants.gcs_compute_endpoint_id",
-        "DATA.$": "$.iterator_vars.intermidate_transfer_data"
+        "destination_endpoint.$": "$.constants.gcs_endpoint_id",
+        "DATA.$": "$.iterator_vars.transfer_from_src_data"
       },
       "ResultPath": "$.transfer_from_src_result",
       "Next" : "RunComputeFunction"
@@ -102,7 +102,7 @@
             "function_id.$": "$.constants.compute_func_id",
             "args": [],
             "kwargs": {
-              "src_path.$" : "$.iterator_vars.compute_src_paths",
+              "src_paths.$" : "$.iterator_vars.compute_src_paths",
               "dest_path.$" : "$.constants.compute_dest_path",
               "transform_from.$": "$.constants.compute_transform_from",
               "transform_to.$": "$.constants.compute_transform_to"
@@ -117,7 +117,7 @@
       "Type": "Action",
       "ActionUrl": "https://transfer.actions.globus.org/transfer",
       "Parameters": {
-        "source_endpoint.$": "$.constants.gcs_compute_endpoint_id",
+        "source_endpoint.$": "$.constants.gcs_endpoint_id",
         "destination_endpoint.$": "$.destination.id",
         "DATA": [
           {
@@ -133,7 +133,7 @@
       "Type": "Action",
       "ActionUrl": "https://transfer.actions.globus.org/delete",
       "Parameters": {
-        "endpoint.$": "$.constants.gcs_compute_endpoint_id",
+        "endpoint.$": "$.constants.gcs_endpoint_id",
         "recursive": true,
         "DATA": [
           {

--- a/compute_transfer_examples/compute_transfer_example_2_definition.json
+++ b/compute_transfer_examples/compute_transfer_example_2_definition.json
@@ -6,10 +6,10 @@
       "Parameters": {
         "gcs_endpoint_id": "<INSERT YOUR GCS ENDPOINT ID HERE>",
         "compute_endpoint_id": "<INSERT YOUR COMPUTE ENDPOINT ID HERE>",
-        "compute_func_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
+        "compute_function_id": "<INSERT YOUR COMPUTE FUNCTION ID HERE>",
         "compute_transform_from": "/",
         "compute_transform_to": "/",
-        "compute_dest_path.=": "'/' + _context.run_id + '/'"
+        "compute_output_directory.=": "'/' + _context.run_id + '/'"
       },
       "ResultPath": "$.constants",
       "Next" : "MakeComputeWorkingDir"
@@ -19,7 +19,7 @@
       "ActionUrl": "https://transfer.actions.globus.org/mkdir",
       "Parameters": {
         "endpoint_id.$": "$.constants.gcs_endpoint_id",
-        "path.$": "$.constants.compute_dest_path"
+        "path.$": "$.constants.compute_output_directory"
       },
       "ResultPath": "$.mkdir_result",
       "Next": "SetSourcePathsIteratorVariables"
@@ -74,8 +74,8 @@
     "EvalSourcePathInfo": {
       "Type": "ExpressionEval",
       "Parameters": {
-        "compute_src_paths.=": "iterator_vars.compute_src_paths + [constants.compute_dest_path + source_path_stat_result.details.name]",
-        "transfer_from_src_data.=": "iterator_vars.transfer_from_src_data + [{'source_path': get_path.source_path, 'destination_path': constants.compute_dest_path + source_path_stat_result.details.name}]",
+        "compute_src_paths.=": "iterator_vars.compute_src_paths + [constants.compute_output_directory + source_path_stat_result.details.name]",
+        "transfer_from_src_data.=": "iterator_vars.transfer_from_src_data + [{'source_path': get_path.source_path, 'destination_path': constants.compute_output_directory + source_path_stat_result.details.name}]",
         "src_paths_iterator_pos.=": "iterator_vars.src_paths_iterator_pos + 1"
       },
       "ResultPath": "$.iterator_vars",
@@ -99,11 +99,11 @@
         "endpoint_id.$": "$.constants.compute_endpoint_id",
         "tasks": [
           {
-            "function_id.$": "$.constants.compute_func_id",
+            "function_id.$": "$.constants.compute_function_id",
             "args": [],
             "kwargs": {
               "src_paths.$" : "$.iterator_vars.compute_src_paths",
-              "dest_path.$" : "$.constants.compute_dest_path",
+              "dest_path.$" : "$.constants.compute_output_directory",
               "transform_from.$": "$.constants.compute_transform_from",
               "transform_to.$": "$.constants.compute_transform_to"
             }
@@ -137,7 +137,7 @@
         "recursive": true,
         "DATA": [
           {
-            "path.$": "$.constants.compute_dest_path"
+            "path.$": "$.constants.compute_output_directory"
           }
         ]
       },

--- a/compute_transfer_examples/compute_transfer_example_2_schema.json
+++ b/compute_transfer_examples/compute_transfer_example_2_schema.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "required": [
+    "source_endpoint",
+    "source_paths",
+    "destination"
+  ],
+  "properties": {
+    "source_endpoint": {
+      "type": "string",
+      "title": "Source Endpoint ID",
+      "description": "The endpoint id of the source collection"
+    },
+    "source_paths": {
+      "type": "array",
+      "title": "Source Collection Paths",
+      "description": "A list of paths on the source collection for the data"
+    },
+    "destination": {
+      "type": "object",
+      "title": "Destination",
+      "format": "globus-collection",
+      "required": [
+        "id",
+        "path"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Destination Collection ID",
+          "format": "uuid",
+          "description": "The endpoint id of the destination collection"
+        },
+        "path": {
+          "type": "string",
+          "title": "Destination Collection Path",
+          "description": "The path on the destination collection to transfer the compute output"
+        }
+      },
+      "description": "The destination for the data",
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/compute_transfer_examples/register_compute_func.py
+++ b/compute_transfer_examples/register_compute_func.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+from typing import Union, List
+
+def do_tar(
+    src_paths: Union[List[str], str],
+    dest_path: str,
+    transform_from: str = "/",
+    transform_to: str = "/",
+) -> str:
+    import tarfile
+    import uuid
+    from pathlib import Path
+
+    """
+    Create a tar.gz archive from source files or directories and save it to the given destination.
+    
+    This function transforms provided GCS-style paths to absolute filesystem paths using the given
+    `transform_from` and `transform_to` prefixes. It verifies that all source paths exist and that the 
+    destination path is valid. If the destination is an existing directory, a unique tar.gz filename is 
+    generated. If a file path is provided (which may not exist yet), its parent directory must exist.
+    
+    Parameters:
+        src_paths (Union[List[str], str]):  Source path(s) of file(s) or directory/directories to be archived.
+                                            Can be a single path string or a list of path strings.
+        dest_path (str): Destination path where the tar.gz archive will be written. This can be either 
+                         an existing directory or a file path (with the parent directory existing).
+        transform_from (str): The prefix in the provided paths that will be replaced. Default is "/".
+        transform_to (str): The prefix to use when converting to absolute filesystem paths. Default is "/".
+    
+    Returns:
+        str: The output tar.gz file path, transformed back to the original GCS-style path.
+    
+    Raises:
+        ValueError: If src_paths is empty, dest_path is None, any provided path does not begin with the expected
+                    prefix, or if any source path or destination (or its parent) is invalid.
+        RuntimeError: If an error occurs during the creation of the tar.gz archive.
+    
+    Example:
+        >>> output = do_tar(
+        ...     src_paths=["/file1.txt", "/dir1/file2.txt"],
+        ...     dest_path="/tar_output",
+        ...     transform_from="/",
+        ...     transform_to="/path/to/root/"
+        ... )
+        >>> print(output)
+        /tar_output/7f9c3f9a-2d75-4d2f-8b0a-0f0d7e6b1e3a.tar.gz
+    """
+
+    def transform_path_to_absolute(path: str) -> str:
+        """Transform a GCS-style path to an absolute filesystem path."""
+        if not path.startswith(transform_from):
+            raise ValueError(
+                f"Path '{path}' does not start with the expected prefix '{transform_from}'."
+            )
+        return path.replace(transform_from, transform_to, 1)
+
+    def transform_path_from_absolute(path: str) -> str:
+        """Transform an absolute filesystem path back to a GCS-style path."""
+        if not path.startswith(transform_to):
+            raise ValueError(
+                f"Path '{path}' does not start with the expected prefix '{transform_to}'."
+            )
+        return path.replace(transform_to, transform_from, 1)
+
+    # Convert single string path to a list for uniform processing
+    if isinstance(src_paths, str):
+        src_paths = [src_paths]
+    
+    # Validate src_paths and dest_path
+    if not src_paths:
+        raise ValueError("src_paths must not be empty.")
+    if dest_path is None:
+        raise ValueError("dest_path must not be None.")
+
+    # Transform destination path
+    transformed_dest_path = Path(transform_path_to_absolute(dest_path))
+    
+    # Transform and validate all source paths
+    transformed_src_paths = []
+    for src_path in src_paths:
+        transformed_src_path = Path(transform_path_to_absolute(src_path))
+        if not transformed_src_path.exists():
+            raise ValueError(f"Source path '{src_path}' does not exist.")
+        transformed_src_paths.append(transformed_src_path)
+
+    # Validate transformed_dest_path
+    if transformed_dest_path.exists():
+        if not (transformed_dest_path.is_dir() or transformed_dest_path.is_file()):
+            raise ValueError(f"Destination path '{dest_path}' is neither a directory nor a file.")
+    else:
+        if not transformed_dest_path.parent.exists():
+            raise ValueError(
+                f"Parent directory of destination path '{dest_path}' does not exist."
+            )
+
+    # Determine the final tar file path.
+    if transformed_dest_path.exists() and transformed_dest_path.is_dir():
+        # If destination is an existing directory, generate a unique tar file name.
+        tar_file_name = f"{uuid.uuid4()}.tar.gz"
+        transformed_dest_tar_path = transformed_dest_path / tar_file_name
+    else:
+        # Destination is treated as a file path.
+        fn = transformed_dest_path.name
+        if fn.endswith(".gz"):
+            transformed_dest_tar_path = transformed_dest_path
+        elif fn.endswith(".tar"):
+            transformed_dest_tar_path = transformed_dest_path.with_name(fn + ".gz")
+        else:
+            transformed_dest_tar_path = transformed_dest_path.with_name(fn + ".tar.gz")
+    
+    # Informative message (could be replaced with logging.info in production code)
+    print(f"Creating tar file at {transformed_dest_tar_path.absolute()} with {len(transformed_src_paths)} source(s)")
+    
+    # Create the tar.gz archive with exception handling.
+    try:
+        with tarfile.open(transformed_dest_tar_path, "w:gz") as tar:
+            for src_path in transformed_src_paths:
+                tar.add(src_path, arcname=src_path.name)
+    except Exception as e:
+        # Attempt to remove any incomplete tar file.
+        if transformed_dest_tar_path.exists():
+            try:
+                transformed_dest_tar_path.unlink()
+            except Exception as unlink_err:
+                print(f"Warning: Failed to remove incomplete tar file '{transformed_dest_tar_path}': {unlink_err}")
+        raise RuntimeError(f"Failed to create tar archive: {e}") from e
+
+    # Transform the output path back to a GCS-style path and return.
+    result_path = transform_path_from_absolute(str(transformed_dest_tar_path.absolute()))
+    return result_path
+
+
+if __name__ == "__main__":
+    from globus_compute_sdk import Client
+
+    gcc = Client()
+    do_tar_fuid = gcc.register_function(do_tar)
+    print(f"Tar func UUID is {do_tar_fuid}")
+


### PR DESCRIPTION
Created two example Compute and Transfer flows and a script to register the Compute function both examples invoke.
- Example flow 1 takes a user-provided list of source files that already exists in the co-located GCS collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection.
- Example flow 2 takes in a user-provided list source files that exists on a user provided source collection, creates a tarfile from it, and transfers the tarfile to a user provided destination collection.