### PR TITLE
Add a schema for validating .doc_config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,10 @@ repos:
     rev: 0.33.0
     hooks:
       - id: check-github-workflows
+      - id: check-jsonschema
+        args: ["--schemafile", "support/doc_config_schema.json"]
+        files: "\\.doc_config\\.yaml"
+        types: [yaml]
 
   - repo: "https://github.com/sirosen/texthooks"
     rev: 0.6.8

--- a/support/build-doc-bundle.py
+++ b/support/build-doc-bundle.py
@@ -192,7 +192,7 @@ def build_index_doc(configs: list[ExampleDocBuildConfig]) -> bytes:
 
 def load_config(config_file: pathlib.Path) -> ExampleDocBuildConfig:
     with open(config_file, "rb") as fp:
-        raw_config_data = yaml.load(fp, Loader=yaml.Loader)
+        raw_config_data = yaml.safe_load(fp)
 
     if not isinstance(raw_config_data, dict):
         _abort(f"cannot fetch yaml data from {config_file}, non-dict config?")

--- a/support/doc_config_schema.json
+++ b/support/doc_config_schema.json
@@ -1,0 +1,81 @@
+{
+  "title": ".doc_config.yaml Validation Schema",
+  "description": "This schema describes the shape of our internal doc configs. It is used to validate configs so that the build script doesn't need to do this checking.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "unevaluatedProperties": false,
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "short_description": {
+      "type": "string"
+    },
+    "example_dir": {
+      "type": "string"
+    },
+    "index_source": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/index_source_copy"
+        },
+        {
+          "$ref": "#/$defs/index_source_concat"
+        }
+      ]
+    },
+    "append_source_blocks": {
+      "type": "boolean"
+    },
+    "menu_weight": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "short_description",
+    "example_dir",
+    "index_source",
+    "append_source_blocks",
+    "menu_weight"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "index_source_copy": {
+      "type": "object",
+      "properties": {
+        "copy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "copy"
+      ],
+      "additionalProperties": false
+    },
+    "index_source_concat": {
+      "type": "object",
+      "properties": {
+        "concat": {
+          "type": "object",
+          "properties": {
+            "files": {
+              "$ref": "#/$defs/string_array",
+              "minItems": 1
+            }
+          },
+          "required": [
+            "files"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "string_array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/support/doc_config_schema.json
+++ b/support/doc_config_schema.json
@@ -2,7 +2,6 @@
   "title": ".doc_config.yaml Validation Schema",
   "description": "This schema describes the shape of our internal doc configs. It is used to validate configs so that the build script doesn't need to do this checking.",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "unevaluatedProperties": false,
   "properties": {
     "title": {
       "type": "string"

--- a/transfer_examples/move/.doc_config.yaml
+++ b/transfer_examples/move/.doc_config.yaml
@@ -8,7 +8,8 @@ short_description: |
     be copied to the destination and then deleted from the source.
 
 example_dir: 'move_flow'
-readme_is_index: true
+index_source:
+  copy: "README.adoc"
 append_source_blocks: true
 
 menu_weight: 100

--- a/transfer_examples/transfer_after_approval/.doc_config.yaml
+++ b/transfer_examples/transfer_after_approval/.doc_config.yaml
@@ -5,7 +5,8 @@ short_description: |
     destination Guest Collection.
 
 example_dir: 'transfer_after_approval'
-readme_is_index: true
+index_source:
+  copy: "README.adoc"
 append_source_blocks: true
 
 menu_weight: 300

--- a/transfer_examples/two_hop/.doc_config.yaml
+++ b/transfer_examples/two_hop/.doc_config.yaml
@@ -5,7 +5,8 @@ short_description: |
     destination. Remove from intermediate after completion.
 
 example_dir: 'two_hop'
-readme_is_index: true
+index_source:
+  copy: "README.adoc"
 append_source_blocks: true
 
 menu_weight: 200


### PR DESCRIPTION
This is a simple JSON Schema for validating the .doc_config.yaml
files.

Additionally, add a mode for concatenating the `index.adoc` file for
an example page from fragments in the current directory -- this is
anticipated based on examination for the tar-and-transfer example,
which probably needs to be broken down into several files.

Writing the config to allow for this was an initial trial of the
schema's internal consistency and usability. As a side-effect of the
refactor, the 'readme_is_index' config was replaced with a config of
the form

    {"copy": "README.adoc"}

which will probably be the norm for examples, but about which we can
be flexible in the future.

With the schema in place, updates to the doc build script include the
removal of type checks, as we can rely on the schema to do this work.
