### PR TITLE
Build links to the Flows IDE for rendered pages

### DIFF
--- a/compute_transfer_examples/tar_and_transfer/.doc_config.yaml
+++ b/compute_transfer_examples/tar_and_transfer/.doc_config.yaml
@@ -7,6 +7,7 @@ short_description: |
     Two examples are included here, one in which the files are located on the
     server which runs Globus Compute, and one in which the files are on a user's
     machine and must be moved to the Compute host.
+include_ide_link: false
 
 example_dir: 'compute_tar_and_transfer'
 append_source_blocks: false

--- a/compute_transfer_examples/tar_and_transfer/collection_transfer_requires_flow/.doc_config.yaml
+++ b/compute_transfer_examples/tar_and_transfer/collection_transfer_requires_flow/.doc_config.yaml
@@ -12,6 +12,7 @@ short_description: |
     They are expected to be invoked from the Globus webapp when initating a transfer
     where the source / destination collections have an `associated_flow_policy`
     with this flow.
+include_ide_link: false
 
 example_dir: 'collection_transfer_requires_flow'
 append_source_blocks: false

--- a/support/doc_config_schema.json
+++ b/support/doc_config_schema.json
@@ -30,6 +30,9 @@
     },
     "menu_weight": {
       "type": "integer"
+    },
+    "include_ide_link": {
+      "type": "boolean"
     }
   },
   "required": [

--- a/transfer_examples/looping_batched_move/README.adoc
+++ b/transfer_examples/looping_batched_move/README.adoc
@@ -1,5 +1,7 @@
 = Looping Batched Move
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 [TIP]
 =====
 This example is a demonstration of looping in a **flow**.

--- a/transfer_examples/move/README.adoc
+++ b/transfer_examples/move/README.adoc
@@ -1,5 +1,7 @@
 = Move (copy and delete) files
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 == Description
 
 Perform a 'move' operation on a directory by first transferring from a source to a destination and then deleting from the source.

--- a/transfer_examples/simple/README.adoc
+++ b/transfer_examples/simple/README.adoc
@@ -1,5 +1,7 @@
 = Simple Transfer
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 == Description
 
 Do a single file or directory transfer with a 15 minute time limit.

--- a/transfer_examples/transfer_after_approval/README.adoc
+++ b/transfer_examples/transfer_after_approval/README.adoc
@@ -1,5 +1,7 @@
 = Transfer After Approval
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 == Description
 
 Allow users to submit an approval request to transfer a file to a destination Guest Collection.

--- a/transfer_examples/transfer_share/README.adoc
+++ b/transfer_examples/transfer_share/README.adoc
@@ -1,5 +1,7 @@
 = Transfer and Share Files
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 == Description
 
 Move and share files by transferring them to a Guest Collection.

--- a/transfer_examples/two_hop/README.adoc
+++ b/transfer_examples/two_hop/README.adoc
@@ -1,5 +1,7 @@
 = Two Stage Globus Transfer
 
+link:{flows_ide_link}[Try it out in the Flows IDE.^]
+
 == Description
 
 Transfer from source to intermediate and then from intermediate to destination.


### PR DESCRIPTION
Update the `build-doc-bundle` script to create a gzip-encoded link to the example flows in the Flows IDE.

The IDE link is passed to the asciidoc content by setting it as an attribute of the doc, which the content can then reference in a `link:` directive.
For now, as a simple matter of simplicity and uniformity, the link is dropped, unadorned, at the top of each page where it is supported.

Because the compute examples contain multiple definitions and therefore can't build simple links, an exclude config is supported to disable the links for these examples.

---

I've done a test render and confirmed that the Flows IDE is able to read these links.
Here's what a render will look like on the docs site:
<img width="725" height="471" alt="image" src="https://github.com/user-attachments/assets/14e2b49e-350b-4bd5-8bd6-8871590538c2" />